### PR TITLE
Move some functions to data_manage.py from page.py

### DIFF
--- a/domain_context/default_values.py
+++ b/domain_context/default_values.py
@@ -15,5 +15,4 @@ DEFAULT_VALUES = {
     "df_grades": None,
 
     "df_search_result": None,
-    "df_grades_with_cost": None
  }


### PR DESCRIPTION
下記の変更を実施。ブラウザでの動作確認済み。
- calculate_costs、search_car_meet_customer_needsのメソッドをpage.pyからdata_manager.pyへ移動
- DataManagerとUserSessionが依存しないように引数で必要な情報は与えるようにメソッドを修正
- df_grades_with_costをSession Stateで保持する必要が無いため、該当部分を削除

テストを追加していないため、別途対応予定